### PR TITLE
Handle formula cell types in sheet evaluation

### DIFF
--- a/src/main/java/tech/upstream/excel/WorkbookEvaluator.java
+++ b/src/main/java/tech/upstream/excel/WorkbookEvaluator.java
@@ -116,8 +116,8 @@ public class WorkbookEvaluator {
       catch(Exception ex) { } // Ignore
       if(source!=null) {
         switch(source.getCellTypeEnum()) {
-        case FORMULA:
         case NUMERIC: v = source.getNumericCellValue(); break;
+        case FORMULA: v = getCellValue(source); break;
         case STRING: v = source.getStringCellValue(); break;
         default:
           throw new IllegalArgumentException("Unable to copy value from: "+source + " // " + source.getCellTypeEnum() +" // " + v );

--- a/src/main/java/tech/upstream/excel/WorkbookEvaluator.java
+++ b/src/main/java/tech/upstream/excel/WorkbookEvaluator.java
@@ -116,6 +116,7 @@ public class WorkbookEvaluator {
       catch(Exception ex) { } // Ignore
       if(source!=null) {
         switch(source.getCellTypeEnum()) {
+        case FORMULA:
         case NUMERIC: v = source.getNumericCellValue(); break;
         case STRING: v = source.getStringCellValue(); break;
         default:
@@ -123,7 +124,7 @@ public class WorkbookEvaluator {
         }
       }
     }
-    
+
     switch(cell.getCellTypeEnum()) {
     case FORMULA: 
       cell.setCellType(CellType.NUMERIC);


### PR DESCRIPTION
This PR adds support for the `FORMULA` case in `WorkbookEvaluator.setCellValue`, allowing calls to the excel-server API to successfully write cells with embedded formulas.